### PR TITLE
Fix typo with home path detection.

### DIFF
--- a/lib/hobo/lib/seed/seed.rb
+++ b/lib/hobo/lib/seed/seed.rb
@@ -76,7 +76,7 @@ module Hobo
         class << self
           def name_to_url name
             path = File.expand_path name
-            if name.match(/^(\.|\/|\/~)/) && path
+            if name.match(/^(\.|\/|~)/) && path
               path
             else
               "git@github.com:inviqa/hobo-seed-#{name}"


### PR DESCRIPTION
/~ - incorrect
~/ - misses edge case of ~user
~ - captures both uses of ~/ and ~user/, without adding a character mistaken to be used by Github project names
