### PR TITLE
TMUP-329 - Bundler 1.6.5+ compatibility

### DIFF
--- a/lib/hobo/bundler.rb
+++ b/lib/hobo/bundler.rb
@@ -33,8 +33,7 @@ module Hobo
         puts "Failed to install dependencies. Hobo can not proceed."
         puts "Please see the error below:"
         puts
-        puts exception.message
-        puts exception.backtrace
+        raise
       end
     end
 


### PR DESCRIPTION
Bundler sets root to the project Gemfile directory by default.
The bundler isolation in hobo attempts to reset that to make sure all deps are present.
The following commit adds an additional step required for resetting that state:

https://github.com/bundler/bundler/commit/4870340132878c30d49a5d5fc27257e2abe46e7e

Ancillary issues that masked the original error have also been fixed.
