### PR TITLE
#16 Fix relative paths to tools folders

### DIFF
--- a/lib/hobo/tasks/assets.rb
+++ b/lib/hobo/tasks/assets.rb
@@ -53,7 +53,7 @@ namespace :assets do
     Hobo.ui.section "Synchronizing assets (download)" do
       env = task.opts[:env] || args[:env] || 'development'
       src = "s3://#{Hobo.project_config.asset_bucket}/#{env}/"
-      dst = "tools/assets/#{env}"
+      dst = "#{Hobo.project_path}/tools/assets/#{env}"
       do_sync src, dst, env, "download"
     end
   end
@@ -64,7 +64,7 @@ namespace :assets do
     Hobo.ui.section "Synchronizing assets (upload)" do
       env = task.opts[:env] || args[:env] || 'development'
       dst = "s3://#{Hobo.project_config.asset_bucket}/#{env}/"
-      src = "tools/assets/#{env}"
+      src = "#{Hobo.project_path}/tools/assets/#{env}"
       Hobo.ui.warning "Please note that asset uploads can be destructive and will affect the whole team!"
       Hobo.ui.warning "Only upload if you're sure your assets are free from errors and will not impact other team members"
       do_sync src, dst, env, "upload"
@@ -76,7 +76,7 @@ namespace :assets do
   project_only
   task :apply do |task, args|
     env = task.opts[:env] || args[:env] || 'development'
-    path = "tools/assets/#{env}"
+    path = "#{Hobo.project_path}/tools/assets/#{env}"
 
     next unless File.exists? path
 

--- a/lib/hobo/tasks/magento.rb
+++ b/lib/hobo/tasks/magento.rb
@@ -114,7 +114,7 @@ namespace :magento do
 
       sync = Hobo::Lib::S3::Sync.new(Hobo.aws_credentials)
 
-      patches_path = "tools/patches"
+      patches_path = "#{Hobo.project_path}/tools/patches"
       incoming_path = "#{patches_path}/incoming"
 
       Hobo.ui.success("Downloading Magento #{config[:magento_edition].capitalize} #{config[:magento_version]} patches")


### PR DESCRIPTION
In some circumstances, hobo isn't run from the project
root, some tasks didn't use the project path to solve this.
