### PR TITLE
Fix Hobofile error backtrace

### DIFF
--- a/lib/hobo/cli.rb
+++ b/lib/hobo/cli.rb
@@ -107,12 +107,12 @@ module Hobo
     def load_hobofiles
       if Hobo.in_project? && File.exists?(Hobo.hobofile_path)
         logger.debug("cli: Loading hobofile @ #{Hobo.hobofile_path}")
-        TOPLEVEL_BINDING.eval File.read(Hobo.hobofile_path)
+        eval(File.read(Hobo.hobofile_path), TOPLEVEL_BINDING, Hobo.hobofile_path)
       end
 
       if File.exists?(Hobo.user_hobofile_path)
         logger.debug("cli: Loading hobofile @ #{Hobo.user_hobofile_path}")
-        TOPLEVEL_BINDING.eval File.read(Hobo.user_hobofile_path)
+        eval(File.read(Hobo.user_hobofile_path), TOPLEVEL_BINDING, Hobo.user_hobofile_path)
       end
     end
 

--- a/spec/hobo/cli_spec.rb
+++ b/spec/hobo/cli_spec.rb
@@ -6,7 +6,7 @@ describe Hobo::Cli do
   hobofile = nil
 
   def test_args args
-    args.concat(['--skip-host-checks'])
+    args.concat([])
   end
 
   before do
@@ -42,6 +42,16 @@ describe Hobo::Cli do
     File.write(Hobo.user_hobofile_path, "namespace :user do\ntask :user do\nend\nend")
     cli.start test_args([])
     Rake::Task["user:user"].should_not be nil
+  end
+
+  it "should present Hobofile path in eval error" do
+    FileUtils.mkdir_p(File.dirname(Hobo.hobofile_path))
+    File.write(Hobo.hobofile_path, "An invalid hobofile")
+    begin
+      cli.start test_args([])
+    rescue Exception => e
+      e.backtrace[0].should match 'Hobofile'
+    end
   end
 
   it "should load project config if present" do


### PR DESCRIPTION
When an error occurs in the Hobofile it is presently reported as coming from <main>. It was broken by this change: https://github.com/inviqa/hobo-gem/commit/d2c11f8f6e1981efcdde1d25b582e326225ea6e3

We swapped:

``` ruby
load Hobo.hobofile_path
```

for 

``` ruby
TOPLEVEL_BINDING.eval File.read(Hobo.hobofile_path)
```

This change was necessary to make the file evaluate in global scope.

The ruby docs on eval (http://www.ruby-doc.org/core-2.1.3/Kernel.html#method-i-eval) suggest we should be able to pass a filename.
