### PR TITLE
Database asset applicator bugged on windows

### DIFF
--- a/lib/hobo/asset_applicators/sqldump.rb
+++ b/lib/hobo/asset_applicators/sqldump.rb
@@ -9,7 +9,7 @@ Hobo.asset_applicators.register /.*\.sql\.gz/ do |file|
   }
 
   begin
-    result = shell(vm_mysql(:db => db) << 'SHOW TABLES; SELECT FOUND_ROWS();', :capture => true)
+    result = shell(vm_mysql(:db => db).pipe('SHOW TABLES; SELECT FOUND_ROWS();', :on => :vm), :capture => true)
     status[:db_exists] = true
     status[:db_has_tables] = !(result.split("\n").last.strip == '0')
   rescue Hobo::ExternalCommandError

--- a/lib/hobo/lib/vm/command.rb
+++ b/lib/hobo/lib/vm/command.rb
@@ -19,18 +19,28 @@ module Hobo
           }.merge(opts)
         end
 
-        def << pipe
-          pipe = "echo #{pipe.shellescape}" if opts[:auto_echo]
-          @pipe = pipe
+        def pipe cmd, pipe_opts = {}
+          pipe_opts = pipe_opts.merge({ :on => :vm })
+          cmd = "echo #{cmd.shellescape}" if @opts[:auto_echo]
+
+          case pipe_opts[:on]
+            when :vm
+              @pipe_in_vm = cmd
+            when :host
+              @pipe = cmd
+            else
+              raise "Unknown pipe source: #{pipe_opts[:on]}"
+          end
           @opts[:psuedo_tty] = false
           return self
         end
 
-        def < pipe
-          pipe = "echo '#{pipe.shellescape}'" if opts[:auto_echo]
-          @pipe_in_vm = pipe
-          @opts[:psuedo_tty] = false
-          return self
+        def << cmd
+          pipe cmd, :on => :host
+        end
+
+        def < cmd
+          pipe cmd, :on => :vm
         end
 
         # TODO Refactor in to ssh helper with similar opts to shell helper


### PR DESCRIPTION
The `SHOW TABLES` command in the SQL dump asset applicator (https://github.com/inviqa/hobo-gem/blob/master/lib/hobo/asset_applicators/sqldump.rb) is bugged on windows due to shellescape not working correctly on windows (a known issue already raised on internal JIRA).

This either needs refactoring to avoid shellescape or the shellescape problem needs fixing.
