### PR TITLE
Add Vagrant Reload task to VM commands

### DIFF
--- a/lib/hobo/tasks/vm.rb
+++ b/lib/hobo/tasks/vm.rb
@@ -72,6 +72,15 @@ namespace :vm do
     end
   end
 
+  desc "Reload VM"
+  task :reload do
+    vagrantfile do
+      Hobo.ui.title "Reloading VM"
+      vagrant_exec 'reload', '--no-provision'
+      Hobo.ui.separator
+    end
+  end
+
   desc "Provision VM"
   task :provision => [ "deps:chef" ] do
      vagrantfile do


### PR DESCRIPTION
Add a new task to the VM related commands to wrap `vagrant reload --no-provision`.

Usage is as follows:
`hobo vm reload`

I decided not to retain any of the dependency tasks used in `start`, to keep it as light as possible. Also an alternative to wrapping `vagrant reload` could have been to call `vm:stop` followed by `vm:start`, however for speed reasons I chose not to do this.
