### PR TITLE
Move duplicated require statments to rspec config

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/spec/hobo/asset_applicator_spec.rb
+++ b/spec/hobo/asset_applicator_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::AssetApplicatorRegistry do
   describe "asset_applicators accessor" do

--- a/spec/hobo/cli_spec.rb
+++ b/spec/hobo/cli_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Cli do
   cli = nil

--- a/spec/hobo/config/file_spec.rb
+++ b/spec/hobo/config/file_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Config::File do
   before do

--- a/spec/hobo/error_handlers/debug_spec.rb
+++ b/spec/hobo/error_handlers/debug_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::ErrorHandlers::Debug do
   before do

--- a/spec/hobo/error_handlers/friendly_spec.rb
+++ b/spec/hobo/error_handlers/friendly_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::ErrorHandlers::Friendly do
   before do

--- a/spec/hobo/help_formatter_spec.rb
+++ b/spec/hobo/help_formatter_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::HelpFormatter do
   help = nil

--- a/spec/hobo/helpers/file_locator_spec.rb
+++ b/spec/hobo/helpers/file_locator_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Helper do
   describe "locate" do

--- a/spec/hobo/helpers/shell_spec.rb
+++ b/spec/hobo/helpers/shell_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Helper do
   describe "bundle_shell" do

--- a/spec/hobo/helpers/vm_command_spec.rb
+++ b/spec/hobo/helpers/vm_command_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Helper do
   before do

--- a/spec/hobo/lib/s3/sync_spec.rb
+++ b/spec/hobo/lib/s3/sync_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Lib::S3::Sync do
   before do

--- a/spec/hobo/lib/seed/project_spec.rb
+++ b/spec/hobo/lib/seed/project_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Lib::Seed::Project do
   pwd = nil

--- a/spec/hobo/lib/seed/replacer_spec.rb
+++ b/spec/hobo/lib/seed/replacer_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Lib::Seed::Replacer do
   before do

--- a/spec/hobo/lib/seed/seed_spec.rb
+++ b/spec/hobo/lib/seed/seed_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Lib::Seed::Seed do
   pwd = nil

--- a/spec/hobo/logging_spec.rb
+++ b/spec/hobo/logging_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Logging do
   before do

--- a/spec/hobo/metadata_spec.rb
+++ b/spec/hobo/metadata_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Metadata do
   before do

--- a/spec/hobo/null_spec.rb
+++ b/spec/hobo/null_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Null do
   it "should return itself for any method call" do

--- a/spec/hobo/paths_spec.rb
+++ b/spec/hobo/paths_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo do
   describe 'project_path' do

--- a/spec/hobo/ui_spec.rb
+++ b/spec/hobo/ui_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo::Ui do
   def test_ui opts = {}

--- a/spec/hobo/util_spec.rb
+++ b/spec/hobo/util_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Hobo do
   describe "in_project?" do


### PR DESCRIPTION
Removes the need to include spec_helper at the top of every spec file by making it default rspec config
