### PR TITLE
Undo the absolute path change to assets:apply

### DIFF
--- a/lib/hobo/tasks/assets.rb
+++ b/lib/hobo/tasks/assets.rb
@@ -76,7 +76,7 @@ namespace :assets do
   project_only
   task :apply do |task, args|
     env = task.opts[:env] || args[:env] || 'development'
-    path = "#{Hobo.project_path}/tools/assets/#{env}"
+    path = "tools/assets/#{env}"
 
     next unless File.exists? path
 


### PR DESCRIPTION
All other occurrences of the change were needed because hobo, if
not run from the project root directory, wouldn't resolve paths correctly.

vm_shell, which all asset applicators use, instead cd's to the project root
on the VM. The host path wouldn't match the VM path
