### PR TITLE
Fixes shell line iterator so it doesn't yield when buffer full

### DIFF
--- a/lib/hobo/helper/shell.rb
+++ b/lib/hobo/helper/shell.rb
@@ -28,9 +28,10 @@ module Hobo
             while line = buf.slice!(/(.*)\r?\n/)
               yield line
             end
+            yield "#{buf}\r" unless buf.empty?
           end
         rescue EOFError
-          # NOP
+          yield buf unless buf.empty?
         end
       end
 


### PR DESCRIPTION
As per title. `shell` presently yields when stream.readpartial buffer fills (typically visible on large streams of text produced in a short amount if time).
If `:indent` is set then this results in gaps in the output where there should not be as per the following example:

```
[3] pry(main)> shell 'ls -l /tmp | head -n 20', :realtime => true, :indent => 32
                                total 2636
                                drwx------ 2 mike mike  4096 Mar  3 14:06 bundler20150303-22966-17dfluh
                                drwx------ 2 mike mike  4096 Mar  4 15:27 bundler20150304-1388-1h8d9na
                                drwx------ 2 mike mike  4096 Mar  4 15:27 bundler20150304-1510-1oxgkec
                                drwx------ 2 mike mike  4096 Mar  4 15:28 bundler20150304-1643-6jakws
                                drwx------ 2 mike mike  4096 Mar  4 12:25 bundler20150304-17058-8f6qqv
                                drwx------ 2 mike mike  4096 Mar  4 12:25 bundler20150304-17468-40m8tt
                                drwx------ 2 mike mike  4096 Mar  4 12:27 bundler20150304-19304-1mpfttk
                                drwx------ 2 mike mike  4096 Mar  4 12:27 bundler20150304-19398-wxnczk
                                drwx------ 2 mike mike  4096 Mar  4 12:57 bundler20150304-19780-i0o4ht
                                drwx------ 2 mike mike  4096 Mar  4 12:57 bundler20150304-19823-105yjyc
                                drwx------ 2 mike mike  4096 Mar  4 12:57 bundler20150304-19937-jux359
                                drwx------ 2 mike mike  4096 Mar  4 13:06 bundler20150304-20803-11qec1k
                                drwx------ 2 mike mike  4096 Mar  4 13:07 bundler20150304-20929-3ixihu
                                drwx------ 2 mike mike  4096 Mar  4 13:10 bundler20150304-21478-4je5c6
                                drwx------ 2 mik                                e mike  4096 Mar  4 13:10 bundler20150304-21584-1ci3x1
                                drwx------ 2 mike mike  4096 Mar  4 13:30 bundler20150304-22051-1sd7jx2
                                drwx------ 2 mike mike  4096 Mar  4 13:31 bundler20150304-22236-e3amce
                                drwx------ 2 mike mike  4096 Mar  4 13:36 bundler20150304-22646-1cnh7m7
                                drwx------ 2 mike mike  4096 Mar  4 13:36 bundler20150304-22760-d330ig
```
