### PR TITLE
Update magento setup-scripts to clean the config cache before running

### DIFF
--- a/lib/hobo/tasks/magento.rb
+++ b/lib/hobo/tasks/magento.rb
@@ -206,6 +206,7 @@ namespace :magento do
     desc "Run magento setup scripts"
     task :run => ['tools:n98magerun']  do
       Hobo.ui.success "Running setup scripts"
+      vm_shell("bin/n98-magerun.phar cache:clean config", :realtime => true, :indent => 2)
       vm_shell("bin/n98-magerun.phar sys:setup:incremental -n", :realtime => true, :indent => 2)
       Hobo.ui.separator
     end


### PR DESCRIPTION
The config cache included magento module version
numbers, so wont upgrade modules that have this cached
