### PR TITLE
Give more choice when applying Magento Patches

### DIFF
--- a/lib/hobo/tasks/magento.rb
+++ b/lib/hobo/tasks/magento.rb
@@ -163,7 +163,14 @@ namespace :magento do
 
         Hobo.ui.info(metadata['description']) unless metadata['description'].nil?
 
-        if ['n','N','no'].include? Hobo.ui.ask('Do you want to apply this patch?')
+        patch_options = %w( yes never skip )
+        answer = Hobo.ui.ask_choice('Do you want to apply this patch?', patch_options)
+
+        if answer == 'skip'
+          next
+        end
+
+        if answer == 'never'
           File.delete file
           File.write("#{patches_path}/#{base_filename}.skip", '')
 


### PR DESCRIPTION
Provide user with Yes/Never/Skip options to allow them to skip the patch just this time, or permanently.
