### PR TITLE
Fix before DSL to place new tasks before the prerequsites of the old task.

### DIFF
--- a/lib/hem/patches/rake.rb
+++ b/lib/hem/patches/rake.rb
@@ -13,7 +13,7 @@ module Rake
       old_task = Rake.application.instance_variable_get('@tasks').delete(task_name)
 
       Hem::Metadata.to_store task_name
-      task task_name => old_task.prerequisites | new_tasks do
+      task task_name => new_tasks | old_task.prerequisites  do
         new_task.call unless new_task.nil?
         old_task.invoke
       end


### PR DESCRIPTION
In debugging why a task set with `before 'vm:up', 'hello:test'`, I found new_tasks appended to the list, instead of prepended.
